### PR TITLE
Fix asking who to interview first.

### DIFF
--- a/game/scenes/1-prologue/welcome_meal.rpy
+++ b/game/scenes/1-prologue/welcome_meal.rpy
@@ -88,7 +88,10 @@ label welcome_meal:
             show susurha silhouette at right with dissolve
 
             # <CHOICE>
-            vivithinking neutral "Let's see. Who should I interview first?"
+            if interview1 == False and interview2 == False and interview3 == False:
+                vivithinking neutral "Let's see. Who should I interview first?"
+            else:
+                vivithinking neutral "Who should I interview next?"
 
             menu:
                 # OPTION 1 


### PR DESCRIPTION
Fixes https://www.notion.so/najmetender/After-selecting-rightmost-character-and-finishing-the-dialogue-the-textbox-still-says-who-should-I-0ea3c3df030a461fb602faa78b803786?pvs=4

Simplest change since there was no text in the narrative for what text to use in this case.