### PR TITLE
Line edits that improve clarity and user experience

### DIFF
--- a/game/scenes/1-prologue/introduction.rpy
+++ b/game/scenes/1-prologue/introduction.rpy
@@ -100,7 +100,7 @@ label introduction:
     vivi neutral "Sorry, this is all just a lot. I must be really tired."
     urshu happy "I could whip up an espresso if you'd like. They are to die for. I personally have one every morning."
     vivi neutral "I think I'm okay for now, but thank you."
-    urshu neutral "Well, in any case, I've actually stopped by to invite you to dinner. The other guests have gathered. I'm sure they're quite eager to meet you."
+    urshu neutral "Well, in any case, I've actually stopped by to invite you to dinner. The other guests have gathered in the dining car. I'm sure they're quite eager to meet you."
 
     # <CHOICE>
     vivi neutral "Um..."

--- a/game/scenes/1-prologue/welcome_meal.rpy
+++ b/game/scenes/1-prologue/welcome_meal.rpy
@@ -61,7 +61,7 @@ label welcome_meal:
     urshu neutral "I hope..."
     urshu neutral "In the meantime, I suggest you begin interviewing your fellow passengers while it is still early in your stay. That {i}is{/i} what you came here for, is it not?"
     vivithinking neutral "I just came here so I could pay my rent."
-    vivi neutral "Okay. I guess I can start. Still wish I had a little more time to get acclimated though."
+    vivi neutral "Okay. I guess I can start. Though I wish I had a little more time to get acclimated."
     urshu neutral "There's never enough time, Miss Sanssouci. Though there is always enough to seek companionship, I daresay!" 
 
     # urshu exits

--- a/game/scenes/2.1-denial/denial_briefing.rpy
+++ b/game/scenes/2.1-denial/denial_briefing.rpy
@@ -25,7 +25,7 @@ label denial_briefing:
     vivi neutral "What's so funny?"
 
     urshu neutral "I apologize, Miss Sanssouci, for not informing you earlier. The cosmic cycle of life and death and life again spirals faster than any of us like to admit."
-    urshu neutral "I digress, Miss Sanssouci, I came to check on you. Last night's excitement did not, ah, sit well with you."
+    urshu neutral "But I digress, Miss Sanssouci. I came to check on you. Last night's excitement did not, ah, sit well with you."
     vivi neutral "To say the least..." 
     vivithinking "How many shots equate to learning you're dead? Is this how Bruce Willis felt?"
     urshu neutral "I was concerned that yesterday's revelations, on top of your physical, temporal distress, were contributing to a less than ideal mental state."

--- a/game/scenes/2.4-depression/depression_briefing.rpy
+++ b/game/scenes/2.4-depression/depression_briefing.rpy
@@ -117,6 +117,9 @@ label depression_briefing:
     urshu "Nothing. I apologize, Miss Sanssouci, for losing my composure."
     show urshu sad -blush
     urshu sad "And I {i}am{/i} sorry."
+#Here starts a reminder for the player: that the chosen person for FR1 will not be available in FR2, i.e. Vivi's "last moments" before the endings
+    urshu neutral "What I meant is, please be careful whom you choose today. It will likely be the last time you will get to speak with them in this plane of existence."
+    urshu neutral "And remember, shall you choose one person now, they will not be available later. Everyone has their own life to give close to."
     urshu neutral "I care for you. Please, give yourself a little more time. Just, be free with it."
 
     hide urshu with dissolve

--- a/game/scenes/2.4-depression/depression_cs1.rpy
+++ b/game/scenes/2.4-depression/depression_cs1.rpy
@@ -14,6 +14,7 @@ label depression_cs1:
 
     #<CHOICE>
     vivithinking neutral "I'm gonna get a drink. I'm sure I'm not the only one who'd want one."
+    vivithinking "As Urshu said, the person I choose now won't be available later. They won't be able to see my final moments."
     menu:
 
         #OPTION 1


### PR DESCRIPTION
Added character lines in Depression briefing and Depresson cs1. The lines remind the player that these are the last choices. Whoever the player choses in FR1 won't be available in FR2