### PR TITLE
Update and implement new dialogue text and branching options for Urshu's romance path.

### DIFF
--- a/game/scenes/2.1-denial/denial_briefing.rpy
+++ b/game/scenes/2.1-denial/denial_briefing.rpy
@@ -53,30 +53,39 @@ label denial_briefing:
         "Go on, already. A story might lift my crow's feet.":
 
             vivi neutral "Go on, already. A story might lift my crow's feet."
-            urshu happy "Once, long ago, I was in the doldrums of an ordinary immortal career...ferrying souls to and fro. From mortal realms to eternal gardens or places eternal but foul." 
+            urshu happy "Once, long ago, a ferryman called... Sursu toiled in the doldrums of an ordinary immortal career... ferrying souls to and fro. From mortal realms to eternal gardens, or places eternal but foul." 
             vivithinking "What did I sign up for?"
             # SOUND: urshu sighs
             play sound sigh
             pause 3.0
-            urshu neutral "One such soul was in great need of me at a time where I was under heightened supervision. My...managers were unhappy with me. This soul begged me a great favor..."
-            urshu angry "And they did so after they ruined something of mine! It was audacious! But this soul only did what they thought was right, for they were in a dire time..."
+            urshu neutral "On one occasion, Sursu the ferryman met a sweet soul who asked of him a great favor. Too great, in reality - a lifeline, of sorts. And Sursu felt less than obliged to help this soul - they’d already tried to destroy the ferryman's precious vessel! It was audacious!" 
+            urshu neutral "Furthermore, the ferryman was under great scrutiny by the gods who managed him. They were aware of his treasonous heart, which wanted to do more than ferry souls to and fro. They knew he yearned for more than those sad, sole voyages could yield..." 
+            urshu neutral "But this sweet soul only did what they thought was right, for they were trapped and lost, with no north star to guide them..."
             vivithinking "I wonder what's for lunch..."
-            urshu neutral "I was in great conflict about it. I had my own life to keep afloat, and this soul's request would certainly sink it. I had a choice to make."
+            urshu neutral "The ferryman was in great conflict about it. He had his own life to keep afloat, so to speak, and this soul's request would certainly sink it. He had a choice to make."
             vivithinking "Oh! Now I remember his name. Urshunabi. God of insufferably long stories."
-            urshu neutral "I acquiesced to the request. I gave this soul what they asked for. And earned trust and recognition. In my dire straits, I had a companion - a lovely one - but I paid an eternal price for it."
-            urshu sad "I could never return home."
+            urshu neutral "The ferryman acquiesced to the request. He gave this sweet, lost soul what they asked for."
+            urshu neutral "He earned their trust and recognition, and a great prize: in his dire straits, he gained a lovely companion - one who came to be his lifeline in turn. But he paid an eternal price for it."
+            urshu sad "The ferryman could never return home."
             vivithinking "Damn. That's...I feel that."
-            urshu happy "But not all was lost. That daring soul I aided? They invited me to their domain and I gained a new home. A safe one..."
+            urshu happy "But not all was lost. That daring soul he aided? They invited him to their domain and he gained a new home. A safe one. A place of wonder and nature and possibility. And, for this weary ferryman, a new life."
             urshu neutral "Is that not a wonder? A tribulation transfigured into triumph? Are you not yourself in dire straits, Miss Sanssouci?"
             vivi neutral "I doubt it. You don't know me, Ursh. I've been in situations nearly as tense."
-            vivithinking "But I wasn't under threat of existential extinction." 
-            urshu neutral "You might reconsider your position. As my story illustrates, your life, now, is a boat heading toward a certain metaphorical iceberg. Would it not be better to face this end with a companion?"
-            vivi "You think you're funny, don't you? Crow's feet, vague stories, iceberg metaphors...am I the Titanic in this situation?"
+            vivithinking "But I've never been under threat of existential extinction before..." 
+            urshu neutral "You might reconsider your position. Much like Sursu the ferryman, your life, now, is a vessel heading toward a certain yet unfathomable destination. Would it not be better to face this end with a companion?"
+            vivi "You think you're funny, don't you? Crow's feet, vague stories, boat trip metaphors...am I the Titanic in this situation?"
             urshu happy "I think I'm just cosmical. I bid you adieu, Miss Sanssouci."
-            hide urshu with dissolve
             vivi neutral "Cosmical? Com-ic-al? Oh my God."
-            vivithinking "I can hardly believe all this, but  I have to. And he's right. I can't do this alone. If there's any chance to get off this train, it's with someone else's help."
-            vivithinking "Let's c-r-a-c-k those knuckles. Time to investigate." 
+            vivi neutral "Wait, Urshu?"
+            urshu neutral "Yes, my dear?"
+            vivi neutral "Why did you tell me all that? The story, with the soul and the sacrifice, and all that guff?"
+            urshu happy "It makes one feel alive, no, to recall the moments where we're at our most alive? And to give those moments life of their own through our words, even when they've long since passed..."
+            vivithinking "Give me a break."
+            urshu happy "And now, I must attend to the day. May you enjoy yours, Miss Sanssouci!"
+            hide urshu with dissolve
+            vivithinking "Sursu the ferryman, eh? Something's going on there." 
+            vivithinking "Jeez, I can hardly believe all this, but I have to. And he's right about the companion. I can't do this alone. If there's any chance to get off this train, it's with someone else's help."
+            vivithinking "Let's get cracking! Time to investigate." 
             #Jump to Character Selector 1
 
     # OPTION 2

--- a/game/scenes/2.2-anger/anger_briefing.rpy
+++ b/game/scenes/2.2-anger/anger_briefing.rpy
@@ -122,7 +122,7 @@ label anger_briefing:
     urshu happy "Games are one method of reversing the naturally lawful decay we all suffer."
     vivithinking neutral "Games don't get rid of wrinkles. Wait. Do they?" 
     vivi neutral "Can you just hand them over already?"
-    urshu neutral "I'm sorry, Miss Sanssouci. These are my special cards. Given to me by...well, someone from so long ago even Asha was a young deity. Humans had yet to walk upright, even. Ah, but you don't look like you want a story like that."
+    urshu neutral "I'm sorry, Miss Sanssouci. These are my special cards. Given to me by...well, someone from so long ago even the Goddess of the Sun herself was but a young deity. Humans had yet to walk upright. Ah, but you don't look like you want a story like that."
     vivithinking neutral "Good read there, honey." 
     vivi neutral "Are there other games, then?"
     urshu sad "..."
@@ -130,7 +130,60 @@ label anger_briefing:
     vivithinking neutral "He's not even speaking in full sentences. Weird." 
     vivi neutral "Uh...Ursh?"
     show urshu sad blush with dissolve
-    urshu "Forgive me...you will find games where you will find your next partner. Whoever shall you challenge? I am positively vibrating with anticipation."
+
+    # <CHOICE>
+    # THIS MENU CHOICE ONLY APPEARS IF VIVI CHOSE TO HEAR URSHU'S FIRST STORY (SELECTED OPTION 1 "Go on, already. A story might lift my crow's feet." IN 2.1 DENIAL_BRIEFING). OTHERWISE, NEEDS TO DEFAULT TO RUNNING OPTION 1 ("Hey, Urshu! Let's keep it moving, shall we?") FROM MENU BELOW.
+    urshu sad "Forgive me... Some days I can barely hold it in my mind's eye. Others... it's as if I could reach out and touch it... Alas..."
+    
+    menu:
+        # OPTION 1
+        "Hey, Urshu! Let's keep it moving, shall we?":
+
+            vivi angry "Hey, Urshu! Let's keep it moving, shall we?"
+            # JUMP TO: urshu "Ah yes, of course...
+
+        # OPTION 2
+        "Look, just tell me the story. If we have time.":
+
+            vivi neutral "Look, just tell me the story. If we have time."
+            urshu happy -blush "Ah Miss Sanssouci, we have so little time and yet far too much of it!"
+            vivi neutral "Yeah, yeah. Just tell it already."
+            urshu neutral "I shall continue the tale of Sursu, the ferryman."
+            vivithinking "'Sursu'. Riiiight."
+            urshu neutral "After his plight, the weary ferryman found himself in the embrace of that sweet soul he helped. Sheltered by the new home that welcomed him."
+            urshu neutral "He tried to be happy and himself in this place, but he could not settle. Cut off from his past, now {i}he{/i} found himself without a north star."
+            vivithinking "Oh boy, I'm in for a loooong one."
+            urshu neutral "The ferryman's eye was too fixed on the home he had lost, which he could never return to."
+            urshu neutral "The air, sweet and serene, suffocated him. The glorious emerald walls kept strife out, but also kept him in. The amber lanterns would not light his way home, for there was none in that place. He would not let it be so."
+            urshu neutral "The sweet soul's gaze could not hold his own. Their touch could not rouse his heart from its numbness. Their very presence was drowned by the potency of his memories."
+            vivithinking angry "Is he ever going to cut the poetic crap and get to the point? I don't have time for this!"
+            urshu neutral "For who are we - what are we - when not refracted through our people and places? The things that make us what we are more than we care to acknowledge?"
+            urshu sad "Like the ocean that changes its hue with the sky, the ferryman lived on, but was an entirely different shade. He felt he did not know himself."
+            vivithinking angry "Well, 'the ferryman' knows himself plenty now, doesn't he? Spinning these self-indulgent yarns at me!"
+            urshu sad "Consumed with longing, the ferryman fled the sweet soul's domain. It was his greatest regret." 
+            urshu sad "Adrift, raftless, in the tides of his... managers' furies, he was captured and confined to yet another life. One he did not choose."
+            urshu sad "Now he lives on, so to speak, filled with a different, but no less dangerous, longing."
+            vivithinking angry "Ok, he's just misery-dumping on me now without being straight with me! Such a fraud!"
+            urshu neutral "Nostalgia is a powerful and perilous thing, Miss Sanssouci."
+            urshu neutral "For the merest moment, it can take us home. But it also can taint our present, and leave us unable to forge a new one."
+            urshu happy "And yet, to swim in nostalgia's balmy waters, even for a moment, is one of life's greatest pleasures! And we must remember who we are, and what made us, to make sense of who we might become."
+            vivi angry "You just love being Mr. Cryptic, don't you? You, with all your little 'stories'!"
+            urshu happy "Myths and tales are a treasure trove of wisdom, no? Especially for those who find themselves unable to focus on the present, Miss Sanssouci."
+            vivi angry "When are you gonna admit that you're talking about you? And that this is just one big sob story?!"
+            urshu neutral "What might have led you to such a conclusion, my dear?"
+            vivi angry "Look, just cut the crap, ok? I'm a journo, this is my whole deal. You can't pull the wool over my eyes, Urshu!"
+            urshu neutral "What a blessing and curse to be beholden to your journalistic proclivities!"
+            vivi angry "You lost your first love and your homes, and you're sad. I get it! But why are you dressing it up with all this 'ferryman' stuff? You're trying to mess with me! Why won't you just be open with me?"
+            urshu neutral "I am sure you appreciate that openness is difficult when time is short. The curtain soon closes and new players await in the wings to begin the play anew. Only the stagehand shall remain. Alone."
+            vivi angry "I'M SICK OF THESE RIDDLES! WHY WON'T YOU JUST BE UPFRONT WITH ME?"
+            urshu angry "I reiterate, Miss Sanssouci, that time is short and we each have our roles to play." 
+            urshu angry "It is for you to use this stage to find meaning in the present and make your curtain call count. Not me."
+            vivi angry "I'm done with you and your games, Urshu!"
+            urshu neutral "Games?"
+            urshu neutral "Games! That quite reminds me..."
+            # JUMP TO: urshu "Ah yes, of course...
+        
+    urshu "Ah yes, of course...you will find games where you will find your next partner. Whoever shall you challenge? I am positively vibrating with anticipation."
     vivithinking neutral "Ew?"
     vivi neutral "I'll be sure to tell you all about it, as long as you stop vibrating...so close to me."
     show urshu happy blush
@@ -139,8 +192,8 @@ label anger_briefing:
     # VISUAL: urshu exits
     hide urshu with dissolve
 
-    vivithinking angry "What the hell does he expect me to do? What will the others think of me? Oh God. Do I play one I know? Then they might think I'm cheating. Maybe I play one they know...but then I might lose."
-    vivithinking happy "Then again, I've never played any game, love or otherwise, I couldn't win."
+    vivithinking angry "What the hell does he expect me to do? What will the others think of me? Oh, God. Do I play one I know? Then they might think I'm cheating. Maybe I play one they know... but then I might lose."
+    vivithinking happy "Then again, I've never played any game I couldn't win. Apart from the dating game. Ha. Hmm."
 
     # JUMP TO: Character Selector 1
     jump anger_cs1

--- a/game/scenes/2.3-bargaining/bargaining_briefing.rpy
+++ b/game/scenes/2.3-bargaining/bargaining_briefing.rpy
@@ -165,8 +165,73 @@ label bargaining_briefing:
     vivi neutral "Yes, I have distractions and good people and tasty espresso--and you here to spice up my life..."
     vivi angry "But I look out of these windows, and all I see is death!"
     vivi sad "I want off this train. Ideally, I want everyone to get off and get back to their lives. I'll do anything to make it happen."
+   
+    # THE BELOW TEXT AND FOLLOWING CHOICE ONLY APPEAR IF VIVI CHOSE TO HEAR BOTH URSHU'S FIRST STORY (SELECTED OPTION 1 "Go on, already. A story might lift my crow's feet." IN 2.1 DENIAL_BRIEFING) AND SECOND STORY (SELECTED OPTION 2 "Look, just tell me the story. If we have time." IN 2.2 ANGER_BRIEFING). OTHERWISE, NEEDS TO JUMP TO urshu neutral "Miss Sanssouci..." BELOW.
+    urshu neutral "It is a wonderful wish, Miss Sanssouci. I wonder..."
+    vivi sad "You wonder what? How you're gonna make that happen?"
+    urshu neutral "I am sure it won't have escaped your journalist's intellect that the stories I have shared with you in our time here... well, I was that ferryman. They were my stories to share."
+    vivithinking "Yeah, no kidding."
+    urshu neutral "And I wonder if you might now care to share one of your own? About the life you so fervently wish to return to."
+    vivi neutral "Wait up, I thought you already knew a ton about us?"
+
+    # <CHOICE>
+    urshu neutral "The deepest secrets of the heart must be shared freely, Miss Sanssouci."
+
+    menu:
+        # OPTION 1
+        "Urgh, ok. You win. What do you want to hear?":
+
+            vivi neutral "Urgh, ok. You win. What do you want to hear?"
+            vivithinking "I bet he wants to hear a {i}secret of the heart{/i}, whatever that means."
+            urshu happy "I wish to hear a memory of your past that tells me best who you are at present."
+            vivi neutral "Uhh..."
+            vivithinking "He really digs nostalgia, huh."
+            vivi neutral "Sure, I can do that. Lemme see..."
+            urshu happy "I await with bated breath, Miss Sanssouci!"
+            vivi neutral "Great. Well, I always loved crazy décor. Always. Like, all-out, the bigger the better. Too much is not enough, y'know?"
+            vivithinking "Oh, he knows. If he had anything to do with the look of this place, anyway."
+            urshu happy "I can only imagine!"
+            vivi neutral "Holidays were amazing. Mom always let me go batshit with the dec's. Birthdays, BBQs, Lunar New Year - everything got tinsel and streamers and confetti, the works. But Halloween was the best."
+            vivi happy "I turned the whole house orange and black. Every year bigger and better. It was a whole thing - people tripping over pumpkins, bats, and skeletons for a week."
+            vivi neutral "But a few years ago I was so busy and I... I screwed up."
+            vivi neutral "I was going after this scoop. It was a big catch for once, not just the usual small fry. I was finally gonna make my name."
+            vivi neutral "I was chasing leads for weeks, and I totally forgot it was Halloween."
+            vivi neutral "I left all the decorations at home. All of them. I was late to Mom's, and then I spent all day on the phone with sources and my editor barking at me."
+            urshu neutral "How out of character that must have seemed."
+            vivi sad "Mom was so sad."
+            vivi sad "I said I was sorry. I told her I was just really busy chasing my dream. I was gonna make her so proud. But she was hurt, and she was worried I was gonna trip up, always looking ahead."
+            vivi neutral "But I fixed it. I raided her fridge, shelves, even her vegetable garden. I rustled up a feast for the whole family."
+            vivi happy "I did it all: dumplings, pumpkin stew, cakes - the lot! Auntie ate so much of my putu piring she had to lie down for hours!"
+            urshu happy "A bountiful bargain!"
+            vivi happy "Yeah. It was."
+            vivi neutral "But I need to do that again. I've been so busy, I've barely been home the past couple years."
+            vivi neutral "With Mom, and Auntie, and everyone... it's not been the same. Not for a while."
+            urshu neutral "It seems your eye has been too fixed upon another time, one out of reach. It has struggled to see the present, and to bask in what it beholds."
+            vivi surprised "I... I mean, I dunno. I guess so. Maybe."
+            urshu neutral "Perhaps you lost your way?"
+            vivi surprised "Maybe a little. Yeah."
+            urshu neutral "And in this, my dear, I think we understand each other perfectly."
+            vivi surprised blush "I... What d'you mean?"
+            urshu neutral "I don't only urge you to use your time aboard this vessel wisely, Miss Sanssouci. I urge you to {i}see{/i} it wisely. Differently."
+            vivithinking blush "Dammit Urshu, why you gotta hit me in the feels like that?! Cunning little..."
+            vivithinking blush "But that does give me an idea."
+            vivi neutral "Look, Ursh..."
+
+            # JUMP TO: urshu neutral "Miss Sanssouci..."
+
+
+        # OPTION 2
+        "Not right now, Urshu. I've got an idea.":
+
+            vivi neutral "Not right now, Urshu. I've got an idea."
+            urshu neutral "Whatever for?"
+            vivi neutral "To get off this ride."
+
+            #JUMP TO: urshu neutral "Miss Sanssouci..."
+    
     urshu neutral "Miss Sanssouci..."
     vivi neutral "Don't \"Miss Sanssouci\" me. I wanna make a deal with you in exchange for my freedom. I want to give you something you haven't had in recent memory."
+
 
     # <CHOICE> 
     vivi "Something that..."

--- a/game/scenes/2.3-bargaining/bargaining_meal_reveal.rpy
+++ b/game/scenes/2.3-bargaining/bargaining_meal_reveal.rpy
@@ -121,6 +121,16 @@ label bargaining_meal_reveal:
     vivithinking neutral "That's not a happy cry. He's covering his mouth."
     vivi neutral "Urshu, what's going on? Why are you crying?"
     urshu sad "Miss Sanssoucci, my dear."
+
+    # THE BELOW TEXT (UP UNTIL LINE 129 INCLUSIVE) ONLY APPEARS IF VIVI CHOSE TO HEAR/TELL ALL THREE STORIES WITH URSHU (SELECTED OPTION 1 "Go on, already. A story might lift my crow's feet." IN 2.1 DENIAL_BRIEFING + SELECTED OPTION 2 "Look, just tell me the story. If we have time." IN 2.2 ANGER_BRIEFING + SELECTED OPTION 1 "Urgh, ok. You win. What do you want to hear?" IN 2.3 BARGAINING BRIEFING). OTHERWISE, NEEDS TO JUMP TO urshu sad "I underestimated you, as I so often do with humans." BELOW
+    urshu sad "Miss Sanssoucci, my dear."
+    vivi neutral "You can just call me Vivi, Ursh."
+    urshu surprised blush "I would like that, Miss Sa- I mean, my dear Vivi."
+    urshu sad -blush "But I must confess..."
+
+    # JUMP TO: urshu sad "I underestimated you, as I so often do with humans."
+    
+  
     urshu sad "I underestimated you, as I so often do with humans."
     vivi neutral "Ursh..."
     urshu sad "I did not think you would complete the task at hand, let alone with a companion."
@@ -135,6 +145,21 @@ label bargaining_meal_reveal:
     urshu neutral "You don't understand! Coffee is different. Coffee is a metaphysical experience."
     urshu neutral "The concept of coffee! Hypothetical productivity with a hint of idealism, mmm! That I can taste. Not the lowly physical aspect."
     vivi angry "No! No! NO! I can't take any more of this. I'm done."
+
+    # Carrie's note - VERSION 1: THE BELOW TEXT (UNTIL LINE 159 INCLUSIVE) ONLY APPEARS IF VIVI CHOSE TO HEAR ALL THREE OF URSHU'S STORIES (SELECTED OPTION 1 "Go on, already. A story might lift my crow's feet." IN 2.1 DENIAL_BRIEFING + SELECTED OPTION 2 "Look, just tell me the story. If we have time." IN 2.2 ANGER_BRIEFING + SELECTED OPTION 1 "Urgh, ok. You win. What do you want to hear?" IN 2.3 BARGAINING BRIEFING). OTHERWISE, NEEDS TO JUMP TO # VERSION 2 BELOW 
+    
+    vivi sad "I cannot believe you, Urshu. That you did this. {i}You.{/i}" 
+    vivi sad "You know, I actually trusted you, more than most. I don't have much time left, but I gave you plenty of it. I heard you out. I listened to you, and all your ferryman stuff."
+    vivi sad "And I opened up to you. I haven't spoken to anyone - {i}anyone{/i} - like that in a long time. You looked me in the eye and said that we understood each other perfectly."
+    vivi sad "I got to feel... I felt like we were..."
+    urshu sad "My dear Vivi?"
+    vivi sad "No. It doesn't matter. Because you clearly don't, and we're clearly not. I thought I was seeing my time here wisely, differently, like you said I should. But maybe I don't have the investigative chops I thought I did." 
+    urshu sad "Dear Vivi, I did not mean to obscure the truth. I tried to tell you numerous times that I do not possess the power to take you off this train, yet you only hear what you want to hear."
+
+    # JUMP TO: stop music fadeout 5.0
+    
+    # Carrie's note - VERSION 2: BASE GAME VERSION (NO URSHU ROMANCE PATH)
+    
     vivi sad "You know, I actually trusted you. You looked me in the eyes and shook my hand, and I trusted you."
     urshu sad "Dear Vivienne, I did not mean to obscure the truth. I tried to tell you numerous times that I do not possess the power to take you off this train, yet you only hear what you want to hear."
 


### PR DESCRIPTION
**game/scenes/2.1-denial/denial_briefing.rpy** - This **Urshu romance path** submission inserts some new and updated dialogue into the existing 2.1 Denial briefing scene between Urshu and Vivi. I’ve tested it locally and it seems to work ok, and the changes shouldn’t affect too much! 


**game/scenes/2.2-anger/anger_briefing.rpy** - This **Urshu romance path** submission inserts some new and updated dialogue into the existing 2.2. Anger briefing scene between Urshu and Vivi, including a new branching-dialogue option (starting at line 134) that lets Vivi choose to either hear another story from Urshu or not. **Please note** that there’s a programming requirement noted in the comments around this new option (lines 134-5): This new choice/option menu only appears if Vivi chose to hear Urshu’s first story (SELECTED OPTION 1 "Go on, already. A story might lift my crow's feet." IN 2.1 DENIAL_BRIEFING). Otherwise, the game needs to default to running Option 1 from the menu ("Hey, Urshu! Let's keep it moving, shall we?"). The idea is that, for Urshu’s romance track, the player needs to opt in to each story-swapping moment/romance-progressing option in order for the subsequent ones to become available. If Vivi turns down any of these moments/options, future ones won’t appear. 

**game/scenes/2.3-bargaining/bargaining_briefing.rpy** - This **Urshu romance path** submission inserts some conditional new dialogue and a choice/option into the existing 2.3 Bargaining briefing scene between Urshu and Vivi (starting at line 169). This lets Vivi choose whether to tell Urhshu a story or not. **Please note** that there’s a programming requirement noted in the comments around this new option (line 169): This new choice/option menu only appears if Vivi chose to hear both Urshu’s first story (SELECTED OPTION 1 "Go on, already. A story might lift my crow's feet." IN 2.1 DENIAL_BRIEFING) and second story (SELECTED OPTION 2 "Look, just tell me the story. If we have time." IN 2.2 ANGER_BRIEFING). Otherwise, the scene needs to jump to urshu neutral "Miss Sanssouci..." (below). Just for ease of reference, as per the 2.2 Anger Urshu romance path submission, the idea is that, for Urshu’s romance track, the player needs to opt in to each story-swapping moment/romance-progressing option in order for the subsequent ones to become available. If Vivi turns down any of these moments/options, future ones won’t appear. 


**game/scenes/2.3-bargaining/bargaining_meal_reveal.rpy** - This **Urshu romance path** submission inserts some minor **conditional** text changes into the 2.3 Bargaining meal reveal scene. **Please note** there are two distinct insertions: 
- Starting at line 125 (please see the programming requirement comment that the player needs to have opted into all three of Urshu’s romance moments until that point)
- Starting line 149 (please see programming requirement note that the ‘Version 1’ text only appears if the player has opted into all three of Urshu’s romance moments until that point, otherwise text defaults to Version 2/the existing game version). 

