### PR TITLE
Susu Path - Denial Fr 2 and Bargaining Fr 1 - dialogue, choice, and expression edits

### DIFF
--- a/game/scenes/2.1-denial/denial_fr2_susurha.rpy
+++ b/game/scenes/2.1-denial/denial_fr2_susurha.rpy
@@ -64,10 +64,10 @@ label denial_fr2_susurha:
 
     susurha sad "To be frank with you, I always believed such tales to be nothing more than a bunch of creative nonsense to make the less fortunate in the clan okay with their shitty life conditions."
 
-    susurha neutral "But..."
+    susurha sad "But..."
 
     # <CHOICE>
-    susurha "I'm beginning to think that those sad old sods that lived in a forest their entire lives weren't completely high as the stars above."
+    susurha sad "I'm beginning to think that those sad old sods that lived in a forest their entire lives weren't completely high as the stars above."
 
     menu:
 
@@ -77,31 +77,31 @@ label denial_fr2_susurha:
             play sound attchoice
         
             vivi "This place freaks me out."
-            susurha "I feel that in my bones. Oh, this place worms its way down my spine like a spider in the night."
-            susurha "Makes me feel like burning the whole place down."
-            susurha "Imagine..."
-            susurha "You're walking in the woods one day, lost in the spiraling storm of every possible thought you've ever had bouncing around in your head, and then..." 
-            susurha "Suddenly finding yourself trapped with a bunch of odd looking individuals, no offense, in a metal tube speeding to an unknown locale."
-            susurha "All the while you're being told that..."
+            susurha angry "I feel that in my bones. Oh, this place worms its way down my spine like a spider in the night."
+            susurha angry "Makes me feel like burning the whole place down."
+            susurha angry "Imagine..."
+            susurha angry "You're walking in the woods one day, lost in the spiraling storm of every possible thought you've ever had bouncing around in your head, and then..." 
+            susurha angry "Suddenly finding yourself trapped with a bunch of odd looking individuals, no offense, in a metal tube speeding to an unknown locale."
+            susurha angry "All the while you're being told that..."
             susurha sad "You are dead."
             vivi "Is that how you died? I mean ended up here."
-            susurha "How you'd figure that?"
-            #JUMP TO: susurha neutral "We will be dead if we stay here any longer."
+            susurha sad "How you'd figure that?"
+            #JUMP TO: susurha sad "We will be dead if we stay here any longer."
 
     #OPTION 2 
         "That's absurd. That can't be the case.":
 
             vivi "That's absurd. That can't be the case."
-            "..."
+            susurha angry "..."
             vivithinking "They're glaring at me. Looking me up and down."
             vivithinking "Alright, chill Vivi. Maybe that was a bit too-"
             susurha angry "Let me tell you what is absurd." 
             susurha angry "You're walking in the woods one day, lost in the spiraling storm of every possible thought you've ever had bouncing around in your head, and then..."
             susurha "Suddenly finding yourself trapped with a bunch of odd looking individuals in a metal tube speeding to an unknown locale."
             susurha angry "All the while you're being told that YOU ARE DEAD."
-            # JUMP TO: susurha neutral "We will be dead if we stay here any longer."
+            # JUMP TO: susurha sad "We will be dead if we stay here any longer."
 
-    susurha neutral "We will be dead if we stay here any longer."
+    susurha sad "We will be dead if we stay here any longer."
 
     vivi "We need to get out of here."
 

--- a/game/scenes/2.1-denial/denial_fr2_susurha.rpy
+++ b/game/scenes/2.1-denial/denial_fr2_susurha.rpy
@@ -58,13 +58,13 @@ label denial_fr2_susurha:
 
     susurha sad "This place is a prison."
 
-    susurha "The Archdruids warned of daemons that kidnap their prey and treat them to endless luxuries."
+    susurha sad "The Archdruids warned of daemons that kidnap their prey and treat them to endless luxuries."
 
-    susurha "Perhaps this is that. We are being fed lies and comfort just so that we can become sooo relaxed and THAT is when they'll strike...to feast on our satisfied souls."
+    susurha sad "Perhaps this is that. We are being fed lies and comfort just so that we can become sooo relaxed and THAT is when they'll strike...to feast on our satisfied souls."
 
-    susurha "To be frank with you, I always believed such tales to be nothing more than a bunch of creative nonsense to make the less fortunate in the clan okay with their shitty life conditions."
+    susurha sad "To be frank with you, I always believed such tales to be nothing more than a bunch of creative nonsense to make the less fortunate in the clan okay with their shitty life conditions."
 
-    susurha "But..."
+    susurha neutral "But..."
 
     # <CHOICE>
     susurha "I'm beginning to think that those sad old sods that lived in a forest their entire lives weren't completely high as the stars above."
@@ -232,6 +232,7 @@ label denial_fr2_susurha:
 
             play sound attchoice
 
+            vivi "It sounds like you lived a fairy tale."
             #SOUND: Susu'Rha laughs.
             # skipping
             susurha "I suppose from the outside it could come across with that poetic fantasy allure."

--- a/game/scenes/2.3-bargaining/bargaining_fr1_susurha.rpy
+++ b/game/scenes/2.3-bargaining/bargaining_fr1_susurha.rpy
@@ -37,7 +37,7 @@ label bargaining_fr1_susurha:
 
     menu:
         # OPTION 1 +DECAY
-        "You're a watchful lizard. What have you noticed?":
+        "You're such an observant lizard.":
 
             play sound decchoice
             show decay_icon at right with dissolve:
@@ -46,7 +46,8 @@ label bargaining_fr1_susurha:
                 yoffset -750
             $ dec_meter += int(dec_max_bargaining / dec_num_bargaining)
 
-            vivi neutral "You're a watchful lizard. What have you noticed?"  
+            vivi neutral "You're such an observant lizard."
+            vivi "I just want to know what you pick up on."
             hide decay_icon
             with { "master" : Dissolve(0.5) }
             susurha angry "The one so seemingly dedicated to self-deception has the temerity to call me a lizard."


### PR DESCRIPTION
Applies changes suggested by QA and from VO work to remedy Susu's expression in Denial Fr2 plus a missing line Vivi says after a choice. Bargaining Fr1 choice text being too long changes were reverted and split to remedy both the issue and keep the original dialogue. I always implemented expression changes in Denial Fr2 that I caught while testing the scene to see if the expressions match the tone of the dialogue better.
